### PR TITLE
Document root deployment sync workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This repository is a GitHub Pages site built using **MkDocs** with the **Materia
 - After modifying a `.md` file, you must trigger a rebuild to update the site.
 
 ### 2. Building the Site
-To apply changes to the web view (`build/site` or root HTML files), run the following from the repository root:
+To build the generated site output, run the following from the repository root:
 ```bash
 cd build && mkdocs build
 ```
@@ -32,12 +32,30 @@ python3 -m venv /tmp/l33t-mkdocs-venv
 cd build && /tmp/l33t-mkdocs-venv/bin/mkdocs build
 ```
 
-### 3. Assets and Images
+### 3. Syncing Root Deployment Output
+GitHub Pages serves this repository from the root. After building, root-level generated files must be synced from `build/site/` before opening or updating a deployment PR:
+```bash
+rsync -av --delete build/site/Blog/ Blog/
+rsync -av --delete build/site/assets/ assets/
+rsync -av --delete build/site/search/ search/
+cp build/site/index.html build/site/404.html build/site/sitemap.xml build/site/sitemap.xml.gz .
+```
+
+Do not sync only `Blog/`. Material for MkDocs emits hashed CSS and JavaScript filenames. If root `Blog/` HTML references new asset hashes but root `assets/` still contains old files, the deployed site can render without styling.
+
+Verify deployment output by checking that the generated page exists and that referenced assets exist, for example:
+```bash
+test -f Blog/<post-slug>/index.html
+test -f assets/stylesheets/<referenced-main-css>.min.css
+test -f assets/javascripts/<referenced-bundle-js>.min.js
+```
+
+### 4. Assets and Images
 - **Images**: New images should be placed in `build/docs/img/` or the appropriate subfolder within it to ensure they are included in the build.
 - **Styles/Scripts**: Modifications to CSS or JS should be made in `assets/`, but be aware that these may be minified during the build process.
 
-### 4. Deployment
-This site is intended for deployment to GitHub Pages. Ensure that any changes to the structure are reflected in the generated `build/site` directory.
+### 5. Deployment
+This site is intended for deployment to GitHub Pages. Ensure that any source changes are reflected in `build/site/` and in the root-served generated files before opening a PR.
 
 ## Important Notes
 - If you encounter errors during the build, check the `mkdocs.yml` configuration for path mismatches or missing dependencies.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The site serves as a personal blog and documentation hub, featuring technical wr
 - `assets/`: Static assets including CSS, JavaScript, and images used by the site.
 - `Blog/`: Generated HTML directory containing individual blog post pages.
 
+GitHub Pages serves this repository from the root, so root-level generated files such as `index.html`, `404.html`, `Blog/`, `assets/`, `search/`, and sitemap files must stay in sync with `build/site/`.
+
 ## ⚙️ Development & Build Instructions
 
 ### Prerequisites
@@ -57,12 +59,25 @@ cd build
 mkdocs build
 ```
 
+Then sync the generated deployment output back to the repository root:
+
+```bash
+cd ..
+rsync -av --delete build/site/Blog/ Blog/
+rsync -av --delete build/site/assets/ assets/
+rsync -av --delete build/site/search/ search/
+cp build/site/index.html build/site/404.html build/site/sitemap.xml build/site/sitemap.xml.gz .
+```
+
+Do not sync only `Blog/`. MkDocs Material uses hashed CSS and JavaScript filenames, so the deployed HTML and `assets/` directory must be updated together or the live site can render without styling.
+
 ## 📝 Contributing
 
 When making changes to the site:
 1. **Modify Source**: Always edit `.md` files within `build/docs/`.
 2. **Promote Drafts**: Drafts from `interview-template/new_post/` must be copied into `build/docs/Blog/` before building.
 3. **Rebuild**: Run `mkdocs build` to update the generated HTML.
-4. **Verify**: Check the `build/site` directory to ensure your changes are reflected correctly.
+4. **Sync Deployment Output**: Copy the matching generated `build/site` files to the repository root before deploying.
+5. **Verify**: Check the root-served page and confirm the referenced CSS/JS assets return `200`.
 
 For more detailed instructions on the development workflow, refer to [AGENTS.md](./AGENTS.md).


### PR DESCRIPTION
Updates README.md and AGENTS.md to document that GitHub Pages serves this repository from the root, so generated root HTML must be synced with matching MkDocs Material assets, search data, and sitemap files after building.